### PR TITLE
Creating ci/cd github action

### DIFF
--- a/.github/workflows/new-or-updated-changes.yml
+++ b/.github/workflows/new-or-updated-changes.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: install-requirements
-        run: python -m pip install --upgrade -r requirements.txt
+        run: python -m pip install --upgrade -r requirements-dev.txt && python -m pip install --upgrade -r requirements.txt
 
       # Runs a set of commands using the runners shell
       - name: run-test-coverage-shell-script

--- a/.github/workflows/new-or-updated-changes.yml
+++ b/.github/workflows/new-or-updated-changes.yml
@@ -33,12 +33,16 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: install-dev-requirements-on-linux
-        run: python -m pip install --upgrade -r requirements-dev.txt
+        run: |
+           python -m pip install --upgrade -r requirements-dev.txt
+           python -m pip install --upgrade -r requirements-linux-dev.txt
         if: matrix.os != 'windows-latest'
 
       - name: install-line-profiler-on-windows
+        run: |
+           python -m pip install --upgrade -r requirements-dev.txt
+           python -m pip install --upgrade -r line-profiler@https://download.lfd.uci.edu/pythonlibs/x2tqcw5k/line_profiler-3.0.2-cp37-cp37m-win_amd64.whl
         if: matrix.os == 'windows-latest'
-        run: python -m pip install --upgrade -r requirements-dev-windows.txt
 
       - name: install-requirements
         run: python -m pip install --upgrade -r requirements.txt

--- a/.github/workflows/new-or-updated-changes.yml
+++ b/.github/workflows/new-or-updated-changes.yml
@@ -1,0 +1,46 @@
+# This is a basic workflow to help you get started with Actions
+
+name: new-or-updated-changes
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8"]
+        os: [windows-latest, ubuntu-18.04]
+
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Runs a single command using the runners shell
+      - name: install-requirements
+        run: python -m pip install --upgrade -r requirements.txt
+
+      # Runs a set of commands using the runners shell
+      - name: run-test-coverage-shell-script
+        run: |
+          ./test-coverage.sh "tests slow-tests"
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-actions@v1
+        if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-18.04'
+        with:
+          env_vars: OS,PYTHON
+          name: codecov-umbrella
+          fail_ci_if_error: true

--- a/.github/workflows/new-or-updated-changes.yml
+++ b/.github/workflows/new-or-updated-changes.yml
@@ -32,17 +32,24 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # Runs a single command using the runners shell
-      - name: install-dev-requirements-on-linux
-        run: |
-           python -m pip install --upgrade -r requirements-dev.txt
-           python -m pip install --upgrade -r requirements-linux-dev.txt
+      - name: install-dev-requirements
+        run: python -m pip install --upgrade -r requirements-dev.txt
+
+      - name: install-dev-requirements-linux-specific
+        run: python -m pip install --upgrade -r requirements-linux-dev.txt
         if: matrix.os != 'windows-latest'
 
-      - name: install-line-profiler-on-windows
-        run: |
-           python -m pip install --upgrade -r requirements-dev.txt
-           python -m pip install --upgrade -r line-profiler@https://download.lfd.uci.edu/pythonlibs/x2tqcw5k/line_profiler-3.0.2-cp37-cp37m-win_amd64.whl
-        if: matrix.os == 'windows-latest'
+      - name: install-line-profiler-on-windows-python-3.6
+        run: python -m pip install line-profiler@https://download.lfd.uci.edu/pythonlibs/x2tqcw5k/line_profiler-3.0.2-cp36-cp36m-win_amd64.whl
+        if: matrix.python-version == '3.6' &&  matrix.os == 'windows-latest'
+
+      - name: install-line-profiler-on-windows-python-3.7
+        run: python -m pip install line-profiler@https://download.lfd.uci.edu/pythonlibs/x2tqcw5k/line_profiler-3.0.2-cp37-cp37m-win_amd64.whl
+        if: matrix.python-version == '3.7' &&  matrix.os == 'windows-latest'
+
+      - name: install-line-profiler-on-windows-python-3.8
+        run: python -m pip install line-profiler@https://download.lfd.uci.edu/pythonlibs/x2tqcw5k/line_profiler-3.0.2-cp38-cp38-win_amd64.whl
+        if: matrix.python-version == '3.8' &&  matrix.os == 'windows-latest'
 
       - name: install-requirements
         run: python -m pip install --upgrade -r requirements.txt

--- a/.github/workflows/new-or-updated-changes.yml
+++ b/.github/workflows/new-or-updated-changes.yml
@@ -36,9 +36,11 @@ jobs:
         run: | 
           python -m pip install --upgrade -r requirements-dev.txt || \
             true && echo "Might have failed on Windows due to line-profiler, will try to install it via another means"
-          if [[ "${OSTYPE}" == "win32" ]] || [[ "${OSTYPE}" == "msys" ]]; then
-             python3 -m pip install line-profiler@https://download.lfd.uci.edu/pythonlibs/x2tqcw5k/line_profiler-3.0.2-cp37-cp37m-win_amd64.whl
-          fi
+
+      - name: install-line-profiler-on-windows
+        if: matrix.os == 'windows-latest'
+        run: python3 -m pip install line-profiler@https://download.lfd.uci.edu/pythonlibs/x2tqcw5k/line_profiler-3.0.2-cp37-cp37m-win_amd64.whl
+
       - name: install-requirements
         run: python -m pip install --upgrade -r requirements.txt
 

--- a/.github/workflows/new-or-updated-changes.yml
+++ b/.github/workflows/new-or-updated-changes.yml
@@ -21,6 +21,8 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
 
+    timeout-minutes: 15
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/new-or-updated-changes.yml
+++ b/.github/workflows/new-or-updated-changes.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           ./test-coverage.sh "tests slow-tests"
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-actions@v1
+        uses: codecov/codecov-action@v1
         if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-18.04'
         with:
           env_vars: OS,PYTHON

--- a/.github/workflows/new-or-updated-changes.yml
+++ b/.github/workflows/new-or-updated-changes.yml
@@ -31,6 +31,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Cache multiple paths
+        uses: actions/cache@v2
+        with:
+          path: |
+             ~/.cache/pip
+             ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-${{ hashFiles('**lockfiles') }}
+
       # Runs a single command using the runners shell
       - name: install-dev-requirements
         run: python -m pip install --upgrade -r requirements-dev.txt

--- a/.github/workflows/new-or-updated-changes.yml
+++ b/.github/workflows/new-or-updated-changes.yml
@@ -32,14 +32,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # Runs a single command using the runners shell
-      - name: install-dev-requirements
-        run: | 
-          python -m pip install --upgrade -r requirements-dev.txt || \
-            true && echo "Might have failed on Windows due to line-profiler, will try to install it via another means"
+      - name: install-dev-requirements-on-linux
+        run: python -m pip install --upgrade -r requirements-dev.txt
+        if: matrix.os != 'windows-latest'
 
       - name: install-line-profiler-on-windows
         if: matrix.os == 'windows-latest'
-        run: python3 -m pip install line-profiler@https://download.lfd.uci.edu/pythonlibs/x2tqcw5k/line_profiler-3.0.2-cp37-cp37m-win_amd64.whl
+        run: python -m pip install --upgrade -r requirements-dev-windows.txt
 
       - name: install-requirements
         run: python -m pip install --upgrade -r requirements.txt

--- a/.github/workflows/new-or-updated-changes.yml
+++ b/.github/workflows/new-or-updated-changes.yml
@@ -33,7 +33,12 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: install-dev-requirements
-        run: python -m pip install --upgrade -r requirements-dev.txt
+        run: | 
+          python -m pip install --upgrade -r requirements-dev.txt || \
+            true && echo "Might have failed on Windows due to line-profiler, will try to install it via another means"
+          if [[ "${OSTYPE}" == "win32" ]] || [[ "${OSTYPE}" == "msys" ]]; then
+             python3 -m pip install line-profiler@https://download.lfd.uci.edu/pythonlibs/x2tqcw5k/line_profiler-3.0.2-cp37-cp37m-win_amd64.whl
+          fi
       - name: install-requirements
         run: python -m pip install --upgrade -r requirements.txt
 

--- a/.github/workflows/new-or-updated-changes.yml
+++ b/.github/workflows/new-or-updated-changes.yml
@@ -48,3 +48,17 @@ jobs:
           env_vars: OS,PYTHON
           name: codecov-umbrella
           fail_ci_if_error: true
+      - name: Archive build and test artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-reports-and-cprofile-reports
+          path: |
+            .coverage
+            .test-run-reports/**/*.*
+            .cprofile/**/*.*
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-coverage-reports
+          path: |
+            .coverage-reports/**/*.*

--- a/.github/workflows/new-or-updated-changes.yml
+++ b/.github/workflows/new-or-updated-changes.yml
@@ -30,8 +30,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # Runs a single command using the runners shell
+      - name: install-dev-requirements
+        run: python -m pip install --upgrade -r requirements-dev.txt
       - name: install-requirements
-        run: python -m pip install --upgrade -r requirements-dev.txt && python -m pip install --upgrade -r requirements.txt
+        run: python -m pip install --upgrade -r requirements.txt
 
       # Runs a set of commands using the runners shell
       - name: run-test-coverage-shell-script

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ In short: Think of it as using the `pandas.describe()` function or running [Pand
   - [Demo](#Demo)
   - [Installation](#installation)
   - [Usage](#usage)
+  - [Developer guide](#developer-guide)
 - [Notebooks](#notebooks)
   - [Jupyter](#jupyter)
   - [Google Colab](#google-colab)
@@ -78,27 +79,7 @@ From the GitHub repo:
 pip install git+https://github.com/neomatrix369/nlp_profiler.git@master
 ```
 
-From the source (only for development purposes):
-
-```bash
-git clone https://github.com/neomatrix369/nlp_profiler
-cd nlp_profiler
-```
-
-```
-python setup.py install
-```
-or 
-
-```
-pip install -e .
-```
-
-or 
-
-```
-pip install --prefix .
-```
+From the source (only for development purposes), see [Developer guide](#developer-guide)
 
 ### Usage
 
@@ -117,6 +98,10 @@ new_text_column_dataset = apply_text_profiling(dataset, 'text_column')
 ```
 
 See [Notebooks](#Notebooks) section for further illustrations.
+
+### Developer guide
+
+See [Developer guide](developer-guide.md) to know how to build, test, and contribute to the library.
 
 ## Notebooks
 

--- a/developer-guide.md
+++ b/developer-guide.md
@@ -1,0 +1,103 @@
+# Developer guide
+
+## Table of content
+- [Install requirements](#install-requirements)
+- [Install nlp-profiler](#install-nlp-profiler)
+- [Tests](#tests)
+- [CI/CD](#ci-cd)
+- [Contribution steps](#contribution-steps)
+
+### Install requirements
+
+```bash
+pip install -r requirements-dev.txt
+pip install -r requirements.txt
+
+```
+
+**Linux/macOS**
+
+Install `line-profiler` for Linux or macOS environments:
+
+```
+pip install -r requirements-linux-dev.txt
+```
+
+**Windows**
+
+Install `line-profiler` for Windows depending on the Python version:
+
+```bash
+# Python 3.6
+python -m pip install line-profiler@https://download.lfd.uci.edu/pythonlibs/x2tqcw5k/line_profiler-3.0.2-cp36-cp36m-win_amd64.whl
+
+# Python 3.7
+python -m pip install line-profiler@https://download.lfd.uci.edu/pythonlibs/x2tqcw5k/line_profiler-3.0.2-cp37-cp37m-win_amd64.whl
+
+# Python 3.8
+python -m pip install line-profiler@https://download.lfd.uci.edu/pythonlibs/x2tqcw5k/line_profiler-3.0.2-cp38-cp38-win_amd64.whl
+```
+
+### Install nlp-profiler
+
+Do the below to start getting reading to work in the developer mode.
+
+```bash
+git clone https://github.com/neomatrix369/nlp_profiler
+cd nlp_profiler
+```
+
+```
+python setup.py install
+```
+or 
+
+```
+pip install -e .
+```
+
+or 
+
+```
+pip install --prefix .
+```
+
+
+### Tests
+
+Run all the tests with coverage information using the below command after all packages have been successfully installed:
+
+```bash
+./test-coverage tests slow-tests
+```
+
+On the tests passing (or partially passing), these folders will be created:
+
+```
+.coverage-reports
+.cprofile
+.test-run-reports
+```
+
+Also files with the name `.coverage*` will be created. The shell script will give enough guidance to be able to know where to find the respective reports.
+
+### CI/CD
+
+We are using GitHub actions to enable this feature. See [.github/workflows](.github/workflows) to find out about the different actions configured to achieve this. See [GitHub Actions docs](https://docs.github.com/en/free-pro-team@latest/actions) for further help.
+
+At the moment we have only implemented the CI part of CI/CD. This is work in progress as of the writing of this doc.
+
+### Contribution steps
+
+In addition to have read the [Contribution guide](#CONTRIBUTING.md), please also follow the steps in the [Table of Contents](#table-of-content) above.
+
+Creating a Pull request will also result in these steps to be executed on Windows and Linux instances via the GitHub action(s).
+
+Any failures on the PR would need to be addressed. More details on specific changes will be addressed at a later time, but the failures in tests or at any othe aspect should more or less indicate the reason for failure. If not, please look for past reported issues under [GitHub issues](https://github.com/neomatrix369/nlp_profiler/issues) or report a new one with the specifics of the issue in hand.
+
+Additional to help the process please also feel free to the amend/improve the GitHub actions under [.github/workflows](.github/workflows).
+
+---
+
+Return to [Developer guide section in the README.md](README.md#developer-guide) <br>
+Return to [README.md](README.md)

--- a/requirements-dev-windows.txt
+++ b/requirements-dev-windows.txt
@@ -1,0 +1,8 @@
+pytest >= 5.4.2
+pytest-cov >= 2.10.0
+pytest-html >= 2.1.1
+pytest-pylint >= 0.15.1
+pytest-runner >= 5.2
+pytest-timeout >= 1.3.3
+line-profiler @ https://download.lfd.uci.edu/pythonlibs/x2tqcw5k/line_profiler-3.0.2-cp37-cp37m-win_amd64.whl
+gitpython

--- a/requirements-dev-windows.txt
+++ b/requirements-dev-windows.txt
@@ -1,8 +1,0 @@
-pytest >= 5.4.2
-pytest-cov >= 2.10.0
-pytest-html >= 2.1.1
-pytest-pylint >= 0.15.1
-pytest-runner >= 5.2
-pytest-timeout >= 1.3.3
-line-profiler @ https://download.lfd.uci.edu/pythonlibs/x2tqcw5k/line_profiler-3.0.2-cp37-cp37m-win_amd64.whl
-gitpython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,8 @@
+pytest >= 5.4.2
+pytest-cov >= 2.10.0
+pytest-html >= 2.1.1
+pytest-pylint >= 0.15.1
+pytest-runner >= 5.2
+pytest-timeout >= 1.3.3
 line-profiler >= 3.0.2
 gitpython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,4 @@ pytest-html >= 2.1.1
 pytest-pylint >= 0.15.1
 pytest-runner >= 5.2
 pytest-timeout >= 1.3.3
-line-profiler >= 3.0.2
 gitpython

--- a/requirements-linux-dev.txt
+++ b/requirements-linux-dev.txt
@@ -1,0 +1,1 @@
+line-profiler >= 3.0.2


### PR DESCRIPTION
Initial attempts to setup CI/CD via Github actions:

- to run the test coverage shell script automatically on new pull requests or commits pushed to master 
- (ditto) to a new or existing branch 
- added codecov report generation per PR/commit activity
- uploading test reports, test coverage reports and cprofile reports per execution

We do have a limitation as outlined via #21 but at least we can check PRs against the build matrices where this works (Ubuntu instances atm).