### PR TITLE
Scope the nbqa analysis to the notebooks folder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,4 @@ repos:
     rev: pre-commit-hooks
     hooks:
       - id: nbqa-black
+        files: ^notebooks/


### PR DESCRIPTION
## Goal or purpose of the PR

Amending the config for `nbqa` to only run analysis of files in the `notebooks` folder, on the back of the discussion in https://github.com/neomatrix369/nlp_profiler/pull/40

## Changes implemented in the PR

`.pre-commit-config.yaml` modified using `files` directive

Thanks @MarcoGorelli for the suggestion