### PR TITLE
Fix GitHub action to build on Windows instances

### DIFF
--- a/.github/workflows/end-to-end-flow.yml
+++ b/.github/workflows/end-to-end-flow.yml
@@ -66,6 +66,7 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: run-test-coverage-shell-script
+        shell: bash
         run: |
           ./test-coverage.sh "tests slow-tests"
       - name: Upload coverage to Codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,4 +98,14 @@ Thanks @ritikjain51 for your contribution originally via PR #13, which was fixed
 
 ---
 
+### GitHub branch `ci-cd-github-action` Fix GitHub to run on Windows instances
+
+Now the build and test action runs on Windows instances as well. Fixes issue reported via #21.
+
+[5e7f999](https://github.com/neomatrix369/nlp_profiler/commit/5e7f99910da27a65237abcae9c409e1b3d462db9)  
+[@neomatrix369](https://github.com/neomatrix369) _Sat Oct 24 16:43:49 2020 +0100_
+
+---
+
+
 Return to [README.md](README.md)


### PR DESCRIPTION
To be able to merge a pull request, there are a few checks:

## Goal or purpose of the PR

GitHub action: attempting to run the test-coverage shellscript on the Windows instances

Fixes issue #21 

## Changes implemented in the PR

Added the `shell: bash` directive to the tasks that executes the build and test package step, so all OS type instances use the `bash` shell as the default shell. As on Windows the default shell is powershell unless specified.