### PR TITLE
Couple of changes: end-to-end-flow and requirements-dev.txt file

### DIFF
--- a/.github/workflows/end-to-end-flow.yml
+++ b/.github/workflows/end-to-end-flow.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    if: (github.event_name == 'pull') || ((github.event_name == 'push') && (contains(toJson(github.event.commits), '[skip ci]') == false))
+    if: contains(toJson(github.event.commits), '[skip ci]') == false
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ gitpython
 pre-commit
 nbqa
 matplotlib
+black >= 20.8b1


### PR DESCRIPTION
## Goal or purpose of the PR

Changes made to make sure the end-to-end flow is not ignore when `[skip ci]` is not used. Also include the right version of `black` for `nbqa` to work from the CLI for developers.

Actioned this on the back of the discussion on PR #53 - thanks @MarcoGorelli 


## Changes implemented in the PR

- `end-to-end-flow.yml` amended by simplifying the `if` directive
- `requirements-dev.txt` amended to include the right version of `black`