### PR TITLE
Add spacy related docs info for Conda users

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ Look at a short demo of the NLP Profiler library at one of these:
 
 ### Installation
 
+Conda/Miniconda environment:
+
+```bash
+conda config --set pip_interop_enabled True
+
+### now perform any of the below paths/options
+```
+
 From PyPi:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -88,12 +88,14 @@ Look at a short demo of the NLP Profiler library at one of these:
 
 ### Installation
 
-Conda/Miniconda environment:
+For Conda/Miniconda environments:
 
 ```bash
 conda config --set pip_interop_enabled True
+pip install "spacy >= 2.3.0,<3.0.0"         # in case spacy is not present
+python -m spacy download en_core_web_sm
 
-### now perform any of the below paths/options
+### now perform any of the below pathways/options
 ```
 
 From PyPi:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ emoji >= 0.5.4
 tqdm == 4.46.0
 joblib >= 0.14.1
 ipython >= 7.12.0
+spacy >= 2.3.0,<3.0.0
 pandas
 swifter >= 1.0.3
 en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.0/en_core_web_sm-2.3.0.tar.gz


### PR DESCRIPTION
## Goal or purpose of the PR

Amended docs to make it clear what steps to perform before installing the `nlp_profiler` when using the `Conda` (i.e. `Miniconda`) environments. 
Ensure spacy is installed and the minimum or higher version.

Related to the issue https://github.com/neomatrix369/nlp_profiler/issues/57.

## Changes implemented in the PR

README.md was amended with an additional section for `Conda` (i.e. `Miniconda`) users. Also `requirements.txt` amended to install `spacy 2.3` or higher