### PR TITLE
Github actions: enabled nightly run of build and test

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,8 +15,7 @@ on:
   schedule:
     # cron expression placeholders (https://crontab.guru/#0_16_*_*_5):
     #       minute hour day(month) month day(week)
-    cron: '0 16 * * 5'    # At 16:00 on Friday
-    branches: [master]
+    - cron: '0 16 * * 5'    # At 16:00 on Friday
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,8 +11,12 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
+  # Docs: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onschedule
   schedule:
-    - cron: '0 16 * * 5'
+    # cron expression placeholders (https://crontab.guru/#0_16_*_*_5):
+    #       minute hour day(month) month day(week)
+    - cron: '0 16 * * 5'    # At 16:00 on Friday
+    - branches: [master]
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,8 +15,8 @@ on:
   schedule:
     # cron expression placeholders (https://crontab.guru/#0_16_*_*_5):
     #       minute hour day(month) month day(week)
-    - cron: '0 16 * * 5'    # At 16:00 on Friday
-    - branches: [master]
+    cron: '0 16 * * 5'    # At 16:00 on Friday
+    branches: [master]
 
 jobs:
   analyze:

--- a/.github/workflows/end-to-end-flow.yml
+++ b/.github/workflows/end-to-end-flow.yml
@@ -12,8 +12,7 @@ on:
   schedule:
     # cron expression placeholders (https://crontab.guru/#0_1_*_*_*): 
     #       minute hour day(month) month day(week)
-    cron: '0 1 * * *'   # at 01:00 every night
-    branches: [ master ]
+    - cron: '0 1 * * *'   # at 01:00 every night
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/end-to-end-flow.yml
+++ b/.github/workflows/end-to-end-flow.yml
@@ -12,8 +12,8 @@ on:
   schedule:
     # cron expression placeholders (https://crontab.guru/#0_1_*_*_*): 
     #       minute hour day(month) month day(week)
-    - cron: '0 1 * * *'   # at 01:00 every night
-    - branches: [ master ]
+    cron: '0 1 * * *'   # at 01:00 every night
+    branches: [ master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/end-to-end-flow.yml
+++ b/.github/workflows/end-to-end-flow.yml
@@ -8,6 +8,12 @@ on:
   push:
   pull_request:
     branches: [ master ]
+  # Docs: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onschedule
+  schedule:
+    # cron expression placeholders (https://crontab.guru/#0_1_*_*_*): 
+    #       minute hour day(month) month day(week)
+    - cron: '0 1 * * *'   # at 01:00 every night
+    - branches: [ master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,4 +186,14 @@ Correct the misspelt term "noun phrase" or "noun phrases" across the codebase
 
 ---
 
+### GitHub branch `enabled-nightly-builds` Github actions: enabled nightly run of build and test
+
+Implemented functionality via PR [#65](https://github.com/neomatrix369/nlp_profiler/pull/65) - details described in the body of the PR.
+
+Enabled nightly run of build and test via Github actions
+
+[dde3172](https://github.com/neomatrix369/nlp_profiler/commit/dde31723b7cb1c1105b9df828bf7429094113de4) [@neomatrix369](https://github.com/neomatrix369) _Sun Nov 14 09:12:33 2021 +0000_
+
+---
+
 Return to [README.md](README.md)


### PR DESCRIPTION
To be able to merge a pull request, there are a few checks:

## Checklist

Please check the options that you have completed and strike-out the options that do not apply via this pull request:

- [x] a clear title and description to the Pull Request has been provided
- [x] you have read
    - [x] the [Contributing doc](https://github.com/neomatrix369/nlp_profiler/blob/master/CONTRIBUTING.md) 
    - [x] the [Developer Guide](https://github.com/neomatrix369/nlp_profiler/blob/master/developer-guide.md)
- [ ] ~the pull request passes the tests (`./test-coverage "tests slow-tests"``) - this will also be visible via the Code coverage report and CI/CD task on the Pull Request~
- [ ] ~you have performed some kind of smoke test by running your changes in an isolated environment i.e. Docker container, Google Colab, Kaggle, etc...~
- [ ] ~the notebooks are updated (see `notebooks` folder, read the [Notebooks](./notebooks/README.md) docs)~
- [x] `CHANGELOG.md` has been updated (please follow the existing format)


## Goal or purpose of the PR

Enabled nightly run of build and test via Github actions

## Changes implemented in the PR

Added the `schedule`  directive to the `on` to the end-to-end-flow workflow (github action)